### PR TITLE
Add profiling colab example to compare triton and torch layers.

### DIFF
--- a/src/profiling/profile_triton_comparison.ipynb
+++ b/src/profiling/profile_triton_comparison.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import flux_triton.modules.layer_norm as triton_layer_norm\n",
+    "import flux.modules.layers as torch_layers\n",
+    "import functools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Tensors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "SHAPE = [1, 256]\n",
+    "x = torch.randn(SHAPE).to(device)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Construct Layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch_ln = torch_layers.LayerNorm(SHAPE).to(device)\n",
+    "liger_ln = triton_layer_norm.LigerLayerNorm(SHAPE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "flux_triton.modules.layer_norm.LigerLayerNorm"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "triton_layer_norm.LigerLayerNorm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change these values to where you want to save\n",
+    "LAYER_NAME = \"LN\"\n",
+    "\n",
+    "TORCH_PROFILE_DIR = f\"./tmp_log/{LAYER_NAME}\"\n",
+    "LIGER_PROFILE_DIR = f\"./tmp_log/{LAYER_NAME}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_profile(\n",
+    "    x: torch.Tensor,\n",
+    "    torch_layer: torch.nn.Module,\n",
+    "    liger_layer: torch.nn.Module,\n",
+    "):\n",
+    "    profile_fn = functools.partial(torch.profiler.profile, \n",
+    "        with_stack=True,\n",
+    "        profile_memory=True,\n",
+    "        with_flops=True,\n",
+    "        use_cuda=True,\n",
+    "        record_shapes=True\n",
+    "    )\n",
+    "    with profile_fn(on_trace_ready=torch.profiler.tensorboard_trace_handler(TORCH_PROFILE_DIR)):\n",
+    "        _ = torch_layer(x)\n",
+    "    with profile_fn(on_trace_ready=torch.profiler.tensorboard_trace_handler(LIGER_PROFILE_DIR)):\n",
+    "        _ = liger_layer(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_6191/3889707400.py:13: FutureWarning: `use_cuda` is deprecated, use `activities` argument instead\n",
+      "  with profile_fn(on_trace_ready=torch.profiler.tensorboard_trace_handler(TORCH_PROFILE_DIR)):\n",
+      "/tmp/ipykernel_6191/3889707400.py:15: FutureWarning: `use_cuda` is deprecated, use `activities` argument instead\n",
+      "  with profile_fn(on_trace_ready=torch.profiler.tensorboard_trace_handler(LIGER_PROFILE_DIR)):\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_profile(\n",
+    "    x = x,\n",
+    "    torch_layer = torch_ln,\n",
+    "    liger_layer = liger_ln\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
We add a colab that runs [torch profiling](https://www.vrushankdes.ai/diffusion-policy-inference-optimization/part-iii---profiling-a-pytorch-forward-pass) between the torch layers and the triton layers to compare inference time and memory use.

Once logs have been downloaded to a local machine, go to this address in your chrome browser: [chrome://tracing](chrome://tracing/) and load the relevant logs to view the differences.

For example, we have these comparisons, showing LigerLayerNorm is currently slower than LayerNorm:

<img width="1013" alt="Screen Shot 2024-09-21 at 2 22 56 PM" src="https://github.com/user-attachments/assets/20998c76-0a18-446d-b265-ce0e24be9fd7">
<img width="1037" alt="Screen Shot 2024-09-21 at 2 23 10 PM" src="https://github.com/user-attachments/assets/a31cde8f-a491-4098-94b0-c337f3a1bcde">
